### PR TITLE
Expiry is no longer calculated server-side

### DIFF
--- a/app/serializers/poll_serializer.rb
+++ b/app/serializers/poll_serializer.rb
@@ -1,8 +1,8 @@
 class PollSerializer < ActiveModel::Serializer
-  attributes :pubId, :title, :seconds_since_creation, :exp_s
+  attributes :pubId, :title, :created_utc, :exp_s
   has_many :responses
 
-  def seconds_since_creation
-    Time.now.to_i - object.created_at.to_i
+  def created_utc
+    object.created_at.utc.iso8601
   end
 end


### PR DESCRIPTION
Removes seconds_since_created property on poll, replaces with created_utc timestamp. This allows for client-side expiry calculation, which removes the need for extra network calls to ensure the time is up to date.